### PR TITLE
remove an invalid vkFreeDescriptorSets call

### DIFF
--- a/app/src/main/cpp/Renderer.cpp
+++ b/app/src/main/cpp/Renderer.cpp
@@ -182,7 +182,6 @@ void Renderer::destroy() {
         mRenderPass = VK_NULL_HANDLE;
 
         // Destroy descriptor sets
-        mVk.FreeDescriptorSets(mDevice, mDescriptorPool, 1, &mDescriptorSet);
         mVk.DestroyDescriptorPool(mDevice, mDescriptorPool, nullptr);
         mVk.DestroyDescriptorSetLayout(mDevice, mDescriptorSetLayout, nullptr);
 
@@ -831,6 +830,7 @@ void Renderer::createDescriptorSet() {
     const VkDescriptorPoolCreateInfo descriptor_pool = {
             .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
             .pNext = nullptr,
+            .flags = 0,
             .maxSets = 1,
             .poolSizeCount = 1,
             .pPoolSizes = &descriptorPoolSize,

--- a/app/src/main/cpp/VkHelper.cpp
+++ b/app/src/main/cpp/VkHelper.cpp
@@ -95,7 +95,6 @@ void VkHelper::initializeDeviceApi(VkDevice device) {
     GET_DEV_PROC(DeviceWaitIdle);
     GET_DEV_PROC(EndCommandBuffer);
     GET_DEV_PROC(FreeCommandBuffers);
-    GET_DEV_PROC(FreeDescriptorSets);
     GET_DEV_PROC(FreeMemory);
     GET_DEV_PROC(GetBufferMemoryRequirements);
     GET_DEV_PROC(GetDeviceQueue);

--- a/app/src/main/cpp/VkHelper.h
+++ b/app/src/main/cpp/VkHelper.h
@@ -98,7 +98,6 @@ public:
     PFN_vkDeviceWaitIdle DeviceWaitIdle = nullptr;
     PFN_vkEndCommandBuffer EndCommandBuffer = nullptr;
     PFN_vkFreeCommandBuffers FreeCommandBuffers = nullptr;
-    PFN_vkFreeDescriptorSets FreeDescriptorSets = nullptr;
     PFN_vkFreeMemory FreeMemory = nullptr;
     PFN_vkGetBufferMemoryRequirements GetBufferMemoryRequirements = nullptr;
     PFN_vkGetDeviceQueue GetDeviceQueue = nullptr;


### PR DESCRIPTION
vkFreeDescriptorSets must not be called if pool is not created with VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT